### PR TITLE
Update for SMAPI 3.0

### DIFF
--- a/MapImageExporter.csproj
+++ b/MapImageExporter.csproj
@@ -50,23 +50,7 @@
     <None Include="manifest.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-  </Target>
 </Project>

--- a/MapImageExporter.csproj
+++ b/MapImageExporter.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>MapImageExporter</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,10 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.1.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -71,12 +68,5 @@
     <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
     <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
     <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-  </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/Mod.cs
+++ b/Mod.cs
@@ -15,7 +15,6 @@ using xTile.Dimensions;
 using RectangleX = Microsoft.Xna.Framework.Rectangle;
 using Rectangle = xTile.Dimensions.Rectangle;
 using StardewValley.Objects;
-using SFarmer = StardewValley.Farmer;
 using Netcode;
 using StardewValley.Network;
 
@@ -24,14 +23,17 @@ namespace MapImageExporter
     public class Mod : StardewModdingAPI.Mod
     {
         public static Mod instance;
-        private ConcurrentQueue<RenderQueueEntry> renderQueue = new ConcurrentQueue<RenderQueueEntry>();
+        private readonly ConcurrentQueue<RenderQueueEntry> renderQueue = new ConcurrentQueue<RenderQueueEntry>();
 
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             instance = this;
 
-            Helper.ConsoleCommands.Add("export", "See 'export help'", exportCommand);
-            GameEvents.UpdateTick += checkRenderQueue;
+            helper.ConsoleCommands.Add("export", "See 'export help'", exportCommand);
+
+            helper.Events.GameLoop.UpdateTicked += checkRenderQueue;
         }
 
         private void exportCommand( string str, string[] args )
@@ -70,9 +72,9 @@ namespace MapImageExporter
                 foreach ( GameLocation loc in Game1.locations )
                 {
                     renderQueue.Enqueue(new RenderQueueEntry(loc, flags));
-                    if ( loc is BuildableGameLocation )
+                    if ( loc is BuildableGameLocation location )
                     {
-                        foreach ( Building building in ( loc as BuildableGameLocation ).buildings )
+                        foreach ( Building building in location.buildings )
                         {
                             if ( building.indoors.Value != null )
                             {
@@ -192,20 +194,18 @@ namespace MapImageExporter
             }
         }
 
-        private void checkRenderQueue( object sender, EventArgs args )
+        /// <summary>Raised after the game state is updated (≈60 times per second).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event arguments.</param>
+        private void checkRenderQueue( object sender, UpdateTickedEventArgs e )
         {
             // Simply doing the export when the command is called can cause issues (not
             // actually rendering, making the game skip a frame, crashing, ...) since
             // the console runs on another thread. Rendering might happen at the same 
             // time as the main game. So instead we're going to render one per frame
             // in the update stage, so things definitely don't interfere.
-
-            RenderQueueEntry toRender = null;
-            if (!renderQueue.TryDequeue(out toRender))
-            {
-                return;
-            }
-            export(toRender);
+            if (renderQueue.TryDequeue(out RenderQueueEntry toRender))
+                export(toRender);
         }
 
         private void export(RenderQueueEntry render)
@@ -629,22 +629,18 @@ namespace MapImageExporter
                 if ( begun )
                     b.End();
                 dev.SetRenderTarget(null);
-                if ( stream != null )
-                    stream.Dispose();
-                if (oldOutput != null)
-                    oldOutput.Dispose();
-                if (output != null)
-                    output.Dispose();
-                if (myLighting != null)
-                    myLighting.Dispose();
+                stream?.Dispose();
+                oldOutput?.Dispose();
+                output?.Dispose();
+                myLighting?.Dispose();
                 //Game1.pixelZoom = oldZoom;
                 Game1.viewport = oldView;
                 Game1.options.zoomLevel = oldZoomL;
             }
 
-            if (loc is DecoratableLocation)
+            if (loc is DecoratableLocation location)
             {
-                foreach (Furniture f in (loc as DecoratableLocation).furniture)
+                foreach (Furniture f in location.furniture)
                 {
                     f.updateDrawPosition();
                 }

--- a/Mod.cs
+++ b/Mod.cs
@@ -199,11 +199,7 @@ namespace MapImageExporter
         /// <param name="e">The event arguments.</param>
         private void checkRenderQueue( object sender, UpdateTickedEventArgs e )
         {
-            // Simply doing the export when the command is called can cause issues (not
-            // actually rendering, making the game skip a frame, crashing, ...) since
-            // the console runs on another thread. Rendering might happen at the same 
-            // time as the main game. So instead we're going to render one per frame
-            // in the update stage, so things definitely don't interfere.
+            // render one location per frame to reduce performance impact.
             if (renderQueue.TryDequeue(out RenderQueueEntry toRender))
                 export(toRender);
         }

--- a/Mod.cs
+++ b/Mod.cs
@@ -604,9 +604,9 @@ namespace MapImageExporter
                 if ( loc.uniqueName.Value != null )
                     name = loc.uniqueName.Value;
 
-                string dirPath = Helper.DirectoryPath + "/../../MapExport";
-                string imagePath = dirPath + "/" + name + ".png";
-                Log.info("Saving " + name + " to " + Path.GetFullPath(imagePath) + "...");
+                string dirPath = Path.Combine(Constants.ExecutionPath, "MapExport");
+                string imagePath = Path.Combine(dirPath, $"{name}.png");
+                Log.info($"Saving {name} to {Path.GetFullPath(imagePath)}...");
 
                 if (!Directory.Exists(dirPath))
                     Directory.CreateDirectory(dirPath);

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "Version": "1.0.5",
   "Description": "Export a map to an image.",
   "UniqueID": "spacechase0.MapImageExporter",
-  "PerSaveConfigs": false,
   "EntryDll": "MapImageExporter.dll",
+  "MinimumApiVersion": "2.9.0",
   "UpdateKeys": [ "Nexus:1073", "Chucklefish:4655" ],
   "spacechase0": "map-image-exporter"
 }

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for SMAPI 3.0 (still compatible with current versions of SMAPI).
* Updates the mod build package and simplifies the build settings.
* Updates a comment which refers to console commands being handled on a separate thread. (It's run on the normal mod thread since SMAPI 2.6.)
* Replaces the hardcoded export path (`../../MapExport`) using SMAPI's `Constants.ExecutionPath`.
* Migrates to the new package reference format.

Let me know if you want me to change anything!